### PR TITLE
Implement MCP tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "better-sqlite3": "^11.0.0",
         "zod": "^3.23.0"
       },
-      "devDependencies": {}
+      "devDependencies": {},
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.24.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,97 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { getSchema } from './tools/get-schema.js';
+import { runQuery } from './tools/run-query.js';
+import { getUserMetrics } from './tools/get-user-metrics.js';
+
+const server = new Server(
+  {
+    name: 'monday-activity-mcp',
+    version: '0.1.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'get_schema',
+        description:
+          'Returns available tables, views, and their columns from the Monday.com activity database. Use this to understand what data is available before querying.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+      {
+        name: 'run_query',
+        description:
+          'Executes a read-only SQL query against the Monday.com activity database. Only SELECT statements are allowed.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sql: {
+              type: 'string',
+              description: 'The SQL SELECT query to execute',
+            },
+          },
+          required: ['sql'],
+        },
+      },
+      {
+        name: 'get_user_metrics',
+        description:
+          'Returns comparative metrics for all users with rankings across total actions, items created, days active, workspaces touched, and boards touched.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  switch (name) {
+    case 'get_schema': {
+      const result = getSchema();
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'run_query': {
+      const result = runQuery(args);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    case 'get_user_metrics': {
+      const result = getUserMetrics();
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(console.error);

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1,0 +1,23 @@
+import Database from 'better-sqlite3';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DB_PATH = join(__dirname, '../../db/monday.db');
+
+let db = null;
+
+export function getDb() {
+  if (!db) {
+    db = new Database(DB_PATH, { readonly: true });
+  }
+  return db;
+}
+
+export function closeDb() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}

--- a/src/tools/get-schema.js
+++ b/src/tools/get-schema.js
@@ -1,0 +1,34 @@
+import { getDb } from '../lib/db.js';
+
+export function getSchema() {
+  const db = getDb();
+
+  const tablesAndViews = db
+    .prepare(
+      `SELECT name, type FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%' ORDER BY type, name`
+    )
+    .all();
+
+  const tables = [];
+  const views = [];
+
+  for (const item of tablesAndViews) {
+    const columns = db.prepare(`PRAGMA table_info('${item.name}')`).all();
+    const schema = {
+      name: item.name,
+      type: item.type,
+      columns: columns.map((col) => ({
+        name: col.name,
+        type: col.type || 'TEXT',
+      })),
+    };
+
+    if (item.type === 'table') {
+      tables.push(schema);
+    } else {
+      views.push(schema);
+    }
+  }
+
+  return { tables, views };
+}

--- a/src/tools/get-user-metrics.js
+++ b/src/tools/get-user-metrics.js
@@ -1,0 +1,59 @@
+import { getDb } from '../lib/db.js';
+
+export function getUserMetrics() {
+  const db = getDb();
+
+  const usersData = db
+    .prepare(
+      `
+      SELECT
+        u.user_id,
+        u.total_actions,
+        u.items_created,
+        COUNT(DISTINCT d.day) as days_active,
+        COUNT(DISTINCT w.workspace_name) as workspaces_touched,
+        COUNT(DISTINCT b.board_id) as boards_touched
+      FROM activity_by_user u
+      LEFT JOIN daily_user_activity d ON u.user_id = d.user_id
+      LEFT JOIN user_workspace_activity w ON u.user_id = w.user_id
+      LEFT JOIN user_board_activity b ON u.user_id = b.user_id
+      GROUP BY u.user_id
+      ORDER BY u.total_actions DESC
+    `
+    )
+    .all();
+
+  const users = usersData.map((user, _, arr) => {
+    const metrics = {
+      total_actions: user.total_actions,
+      items_created: user.items_created,
+      days_active: user.days_active,
+      workspaces_touched: user.workspaces_touched,
+      boards_touched: user.boards_touched,
+    };
+
+    const rankings = {
+      total_actions: computeRank(arr, user, 'total_actions'),
+      items_created: computeRank(arr, user, 'items_created'),
+      days_active: computeRank(arr, user, 'days_active'),
+      workspaces_touched: computeRank(arr, user, 'workspaces_touched'),
+      boards_touched: computeRank(arr, user, 'boards_touched'),
+    };
+
+    return {
+      user_id: user.user_id,
+      metrics,
+      rankings,
+    };
+  });
+
+  return {
+    users,
+    userCount: users.length,
+  };
+}
+
+function computeRank(arr, user, field) {
+  const sorted = [...arr].sort((a, b) => b[field] - a[field]);
+  return sorted.findIndex((u) => u.user_id === user.user_id) + 1;
+}

--- a/src/tools/run-query.js
+++ b/src/tools/run-query.js
@@ -1,0 +1,24 @@
+import { getDb } from '../lib/db.js';
+import { RunQueryInputSchema } from '../schemas/index.js';
+
+export function runQuery(input) {
+  const validation = RunQueryInputSchema.safeParse(input);
+  if (!validation.success) {
+    return { error: validation.error.issues[0].message };
+  }
+
+  const db = getDb();
+  try {
+    const stmt = db.prepare(validation.data.sql);
+    const rows = stmt.all();
+    const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+
+    return {
+      columns,
+      rows,
+      rowCount: rows.length,
+    };
+  } catch (err) {
+    return { error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
- Implements SQLite connection wrapper in `src/lib/db.js` (readonly, singleton pattern)
- Adds `get_schema` tool to return available tables/views and their columns
- Adds `run_query` tool to execute validated SELECT queries only
- Adds `get_user_metrics` tool with user metrics and rankings
- Creates MCP server entry point with stdio transport

Closes #4

## Test plan
- [x] All existing schema validation tests pass (19/19)
- [x] Server syntax validates without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)