### PR TITLE
Fix get_user_metrics to compute from activity table directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,6 @@ Check your cwd. Git pull to make sure we are up to date with the latest default 
 - `activity_by_workspace` (workspace_id, workspace_name, total_actions, unique_users, boards_touched, first_action, last_action)
 - `activity_by_board` (board_id, board_name, workspace_name, total_actions, unique_users, items_created, first_action, last_action)
 - `event_summary` (event, count, unique_users, first_occurrence, last_occurrence)
-- `user_workspace_activity` (user_id, workspace_name, actions, first_action, last_action)
-- `daily_user_activity` (day, user_id, actions)
-- `user_board_activity` (user_id, board_id, board_name, workspace_name, actions, items_created, updates, first_action, last_action)
 
 ## TDD Cycle
 

--- a/src/tools/get-user-metrics.js
+++ b/src/tools/get-user-metrics.js
@@ -7,18 +7,16 @@ export function getUserMetrics() {
     .prepare(
       `
       SELECT
-        u.user_id,
-        u.total_actions,
-        u.items_created,
-        COUNT(DISTINCT d.day) as days_active,
-        COUNT(DISTINCT w.workspace_name) as workspaces_touched,
-        COUNT(DISTINCT b.board_id) as boards_touched
-      FROM activity_by_user u
-      LEFT JOIN daily_user_activity d ON u.user_id = d.user_id
-      LEFT JOIN user_workspace_activity w ON u.user_id = w.user_id
-      LEFT JOIN user_board_activity b ON u.user_id = b.user_id
-      GROUP BY u.user_id
-      ORDER BY u.total_actions DESC
+        user_id,
+        COUNT(*) as total_actions,
+        SUM(CASE WHEN event = 'create_pulse' THEN 1 ELSE 0 END) as items_created,
+        COUNT(DISTINCT DATE(created_at)) as days_active,
+        COUNT(DISTINCT workspace_name) as workspaces_touched,
+        COUNT(DISTINCT board_id) as boards_touched
+      FROM activity
+      WHERE user_id IS NOT NULL AND user_id != '' AND user_id != '-4'
+      GROUP BY user_id
+      ORDER BY total_actions DESC
     `
     )
     .all();

--- a/tests/fixtures/test-db.js
+++ b/tests/fixtures/test-db.js
@@ -27,9 +27,9 @@ export function createTestDb() {
     SELECT
       user_id,
       COUNT(*) as total_actions,
-      SUM(CASE WHEN event = 'create_item' THEN 1 ELSE 0 END) as items_created,
-      SUM(CASE WHEN event = 'update_item' THEN 1 ELSE 0 END) as updates,
-      SUM(CASE WHEN event = 'delete_item' THEN 1 ELSE 0 END) as items_deleted,
+      SUM(CASE WHEN event = 'create_pulse' THEN 1 ELSE 0 END) as items_created,
+      SUM(CASE WHEN event = 'update_column_value' THEN 1 ELSE 0 END) as updates,
+      SUM(CASE WHEN event = 'delete_pulse' THEN 1 ELSE 0 END) as items_deleted,
       MIN(created_at) as first_action,
       MAX(created_at) as last_action
     FROM activity
@@ -40,8 +40,8 @@ export function createTestDb() {
       DATE(created_at) as day,
       COUNT(*) as total_actions,
       COUNT(DISTINCT user_id) as unique_users,
-      SUM(CASE WHEN event = 'create_item' THEN 1 ELSE 0 END) as items_created,
-      SUM(CASE WHEN event = 'update_item' THEN 1 ELSE 0 END) as updates
+      SUM(CASE WHEN event = 'create_pulse' THEN 1 ELSE 0 END) as items_created,
+      SUM(CASE WHEN event = 'update_column_value' THEN 1 ELSE 0 END) as updates
     FROM activity
     GROUP BY DATE(created_at);
 
@@ -64,7 +64,7 @@ export function createTestDb() {
       workspace_name,
       COUNT(*) as total_actions,
       COUNT(DISTINCT user_id) as unique_users,
-      SUM(CASE WHEN event = 'create_item' THEN 1 ELSE 0 END) as items_created,
+      SUM(CASE WHEN event = 'create_pulse' THEN 1 ELSE 0 END) as items_created,
       MIN(created_at) as first_action,
       MAX(created_at) as last_action
     FROM activity
@@ -79,38 +79,6 @@ export function createTestDb() {
       MAX(created_at) as last_occurrence
     FROM activity
     GROUP BY event;
-
-    CREATE VIEW user_workspace_activity AS
-    SELECT
-      user_id,
-      workspace_name,
-      COUNT(*) as actions,
-      MIN(created_at) as first_action,
-      MAX(created_at) as last_action
-    FROM activity
-    GROUP BY user_id, workspace_name;
-
-    CREATE VIEW daily_user_activity AS
-    SELECT
-      DATE(created_at) as day,
-      user_id,
-      COUNT(*) as actions
-    FROM activity
-    GROUP BY DATE(created_at), user_id;
-
-    CREATE VIEW user_board_activity AS
-    SELECT
-      user_id,
-      board_id,
-      board_name,
-      workspace_name,
-      COUNT(*) as actions,
-      SUM(CASE WHEN event = 'create_item' THEN 1 ELSE 0 END) as items_created,
-      SUM(CASE WHEN event = 'update_item' THEN 1 ELSE 0 END) as updates,
-      MIN(created_at) as first_action,
-      MAX(created_at) as last_action
-    FROM activity
-    GROUP BY user_id, board_id;
   `);
 
   return db;
@@ -123,13 +91,13 @@ export function seedTestData(db) {
   `);
 
   const testData = [
-    ['2024-01-15T10:00:00Z', 'create_item', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', null, null, 'group1', '{}'],
-    ['2024-01-15T11:00:00Z', 'update_item', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', 'col1', 'Status', 'group1', '{}'],
-    ['2024-01-16T09:00:00Z', 'create_item', 'item', 'user1', 'acc1', 'ws2', 'Workspace B', 'board2', 'Board 2', 'item2', 'Item 2', null, null, 'group2', '{}'],
-    ['2024-01-16T10:00:00Z', 'create_item', 'item', 'user2', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item3', 'Item 3', null, null, 'group1', '{}'],
-    ['2024-01-16T11:00:00Z', 'update_item', 'item', 'user2', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item3', 'Item 3', 'col1', 'Status', 'group1', '{}'],
-    ['2024-01-17T08:00:00Z', 'delete_item', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', null, null, 'group1', '{}'],
-    ['2024-01-17T09:00:00Z', 'create_item', 'item', 'user3', 'acc1', 'ws1', 'Workspace A', 'board3', 'Board 3', 'item4', 'Item 4', null, null, 'group3', '{}'],
+    ['2024-01-15T10:00:00Z', 'create_pulse', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', null, null, 'group1', '{}'],
+    ['2024-01-15T11:00:00Z', 'update_column_value', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', 'col1', 'Status', 'group1', '{}'],
+    ['2024-01-16T09:00:00Z', 'create_pulse', 'item', 'user1', 'acc1', 'ws2', 'Workspace B', 'board2', 'Board 2', 'item2', 'Item 2', null, null, 'group2', '{}'],
+    ['2024-01-16T10:00:00Z', 'create_pulse', 'item', 'user2', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item3', 'Item 3', null, null, 'group1', '{}'],
+    ['2024-01-16T11:00:00Z', 'update_column_value', 'item', 'user2', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item3', 'Item 3', 'col1', 'Status', 'group1', '{}'],
+    ['2024-01-17T08:00:00Z', 'delete_pulse', 'item', 'user1', 'acc1', 'ws1', 'Workspace A', 'board1', 'Board 1', 'item1', 'Item 1', null, null, 'group1', '{}'],
+    ['2024-01-17T09:00:00Z', 'create_pulse', 'item', 'user3', 'acc1', 'ws1', 'Workspace A', 'board3', 'Board 3', 'item4', 'Item 4', null, null, 'group3', '{}'],
   ];
 
   for (const row of testData) {

--- a/tests/unit/db.test.js
+++ b/tests/unit/db.test.js
@@ -82,9 +82,6 @@ describe('db module', () => {
       assert.ok(viewNames.includes('activity_by_workspace'));
       assert.ok(viewNames.includes('activity_by_board'));
       assert.ok(viewNames.includes('event_summary'));
-      assert.ok(viewNames.includes('user_workspace_activity'));
-      assert.ok(viewNames.includes('daily_user_activity'));
-      assert.ok(viewNames.includes('user_board_activity'));
     });
   });
 });

--- a/tests/unit/get-schema.test.js
+++ b/tests/unit/get-schema.test.js
@@ -52,9 +52,6 @@ describe('getSchema', () => {
     assert.ok(viewNames.includes('activity_by_workspace'));
     assert.ok(viewNames.includes('activity_by_board'));
     assert.ok(viewNames.includes('event_summary'));
-    assert.ok(viewNames.includes('user_workspace_activity'));
-    assert.ok(viewNames.includes('daily_user_activity'));
-    assert.ok(viewNames.includes('user_board_activity'));
   });
 
   it('returns correct columns for activity_by_user view', () => {


### PR DESCRIPTION
## Summary

- Rewrote `get_user_metrics` query to compute all metrics directly from `activity` table
- Removed dependency on 3 non-existent views: `daily_user_activity`, `user_workspace_activity`, `user_board_activity`
- Updated test fixture to match actual upstream schema (only 5 views, not 8)
- Updated CLAUDE.md to reflect actual available views

## Test plan

- [x] All 90 tests pass locally
- [ ] Verify endpoint works on Fly.io after deploy

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)